### PR TITLE
fix: [NEXT-1144] Include parallel routes in page segments when contained within a route group's root

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-app-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader.ts
@@ -471,6 +471,24 @@ const nextAppLoader: AppLoader = async function nextAppLoader() {
     middlewareConfig: middlewareConfigBase64,
   } = loaderOptions
 
+  const routeGroupMatch = name.match(/\(([^)]+)\)/);
+  const routeGroup = routeGroupMatch ? routeGroupMatch[1] : null;
+
+  // Search upwards for parallel segments within routing groups and treat
+  // them as if they're within the same directory as the current pagePath.
+  if (routeGroup) {
+    const absoluteRouteGroupPath = _path.default.join(appDir, `(${routeGroup})`);
+    const parallelSegmentsInRoot = _fs.readdirSync(absoluteRouteGroupPath)
+      .filter(dir => dir.startsWith('@') && isDirectory(_path.default.join(absoluteRouteGroupPath, dir)));
+  
+    for (const segment of parallelSegmentsInRoot) {
+      const newAppPath = `/(${routeGroup})/${segment}/page`;
+      if (!appPaths.includes(newAppPath)) {
+        appPaths.push(newAppPath);
+      }
+    }
+  }
+
   const buildInfo = getModuleBuildInfo((this as any)._module)
   const page = name.replace(/^app/, '')
   const middlewareConfig: MiddlewareConfig = JSON.parse(


### PR DESCRIPTION
### What?
Add upward searching into route group's root directory to find parallel routes that should be treated as such within each of the grouped routes adjacent to it.

### Why?
Currently, having a folder structure such as this:
```
app
- (group)
-- @parallel1
--- default
--- page
-- route
--- @parallel2
---- page
--- @parallel3
---- page
--- page
--- layout
```

Will correctly show the page components of `parallel2` and `parallel3` although will fall back to `default` for `parallel1`. This is because we're only searching for adjacent parallel routes within `/(group)/route` and not looking upwards into `/(group)/` as well.

Even when using the layout within the root of the route group, `parallel1` falls back to `default`.

### How?
Check if there's a group in the page path, combine that group with the app path and then search for folders starting with @.
Add those paths to the `appPaths` object.

Closes NEXT-1144
Fixes #49243

-->
